### PR TITLE
fixed probability function name mismatch

### DIFF
--- a/src/helper_functions.h
+++ b/src/helper_functions.h
@@ -65,7 +65,7 @@ inline double dist(double x1, double y1, double x2, double y2) {
  * @param (mu_x,mu_y)   x and y mean values 
  * @output weight as observation likelihood
  */
-double multivatiate_prob(double sig_x, double sig_y, double x_obs, double y_obs,
+inline double multivariate_prob(double sig_x, double sig_y, double x_obs, double y_obs,
                   		 double mu_x, double mu_y) {
   // calculate normalization term
   double gauss_norm;

--- a/src/particle_filter.cpp
+++ b/src/particle_filter.cpp
@@ -164,7 +164,7 @@ void ParticleFilter::updateWeights(double sensor_range, double std_landmark[],
       double n_n_ldmk_y = map_landmarks.landmark_list[association].y_f;
       
       // Calculate multi-variate Gaussian distribution
-      particle_weight *= multivar_prob(std_landmark[0], std_landmark[1], obs_map_x, obs_map_y, n_n_ldmk_x, n_n_ldmk_y);
+      particle_weight *= multivariate_prob(std_landmark[0], std_landmark[1], obs_map_x, obs_map_y, n_n_ldmk_x, n_n_ldmk_y);
              
       //associations used for debugging
       associations.push_back(association+1);


### PR DESCRIPTION
Hello Oana,

My name is Antonio and I'm a fellow Udacity student.

This pull-request resolves a compilation error I found while testing your solution in the simulator:

```
[ 33%] Building CXX object CMakeFiles/particle_filter.dir/src/particle_filter.cpp.o
/home/jasleon/Kidnapped-Vehicle/src/particle_filter.cpp: In member function ‘void ParticleFilter::updateWeights(double, double*, const std::vector<LandmarkObs>&, const Map&)’:
/home/jasleon/Kidnapped-Vehicle/src/particle_filter.cpp:167:26: error: ‘multivar_prob’ was not declared in this scope; did you mean ‘multivatiate_prob’?
  167 |       particle_weight *= multivar_prob(std_landmark[0], std_landmark[1], obs_map_x, obs_map_y, n_n_ldmk_x, n_n_ldmk_y);
      |                          ^~~~~~~~~~~~~
      |                          multivatiate_prob
make[2]: *** [CMakeFiles/particle_filter.dir/build.make:63: CMakeFiles/particle_filter.dir/src/particle_filter.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:76: CMakeFiles/particle_filter.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

Here is the code change results from the simulator:
![image](https://user-images.githubusercontent.com/37006239/111799559-c1060f00-8890-11eb-9f25-f30fa59fef0a.png)
